### PR TITLE
Disable OLED display for power savings

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,19 @@
 
 ## Bluetooth
 ![soflebluetooth](https://github.com/user-attachments/assets/6c6c1d46-74e9-4e91-8191-667fd3f0ec6d)
+
+### Power saving
+If you would like to maximise battery life, you can disable the built-in OLED
+display. This is done by commenting out the display related lines in
+`config/sofle.conf`. The repository already ships with these options disabled:
+
+```
+# CONFIG_ZMK_DISPLAY is not set
+# CONFIG_ZMK_DISPLAY_STATUS_SCREEN_BUILT_IN is not set
+# CONFIG_ZMK_LV_FONT_DEFAULT_SMALL_MONTSERRAT_26 is not set
+# CONFIG_LV_FONT_DEFAULT_MONTSERRAT_26 is not set
+# CONFIG_ZMK_DISPLAY_WORK_QUEUE_DEDICATED is not set
+```
+
+Building the firmware with these settings will omit NiceView/OLED support,
+reducing power consumption.

--- a/config/sofle.conf
+++ b/config/sofle.conf
@@ -1,11 +1,12 @@
 # Copyright (c) 2020 Ryan Cross
 # SPDX-License-Identifier: MIT
 
-# Uncomment the following line to enable the Sofle OLED Display
-CONFIG_ZMK_DISPLAY=y
-CONFIG_ZMK_DISPLAY_STATUS_SCREEN_BUILT_IN=y
-CONFIG_ZMK_LV_FONT_DEFAULT_SMALL_MONTSERRAT_26=y
-CONFIG_LV_FONT_DEFAULT_MONTSERRAT_26=y
+# The following options enable the built-in OLED display. Comment them out
+# to disable the screen and save battery.
+# CONFIG_ZMK_DISPLAY is not set
+# CONFIG_ZMK_DISPLAY_STATUS_SCREEN_BUILT_IN is not set
+# CONFIG_ZMK_LV_FONT_DEFAULT_SMALL_MONTSERRAT_26 is not set
+# CONFIG_LV_FONT_DEFAULT_MONTSERRAT_26 is not set
 
 # Uncomment these two lines to add support for encoders
 CONFIG_EC11=y
@@ -22,7 +23,7 @@ CONFIG_ZMK_KSCAN_DEBOUNCE_PRESS_MS=1
 CONFIG_ZMK_KSCAN_DEBOUNCE_RELEASE_MS=1
 CONFIG_ZMK_USB_LOGGING=n
 
-CONFIG_ZMK_DISPLAY_WORK_QUEUE_DEDICATED=y
+# CONFIG_ZMK_DISPLAY_WORK_QUEUE_DEDICATED is not set
 
 # Uncomment this line below to add rgb underglow / backlight support
 # CONFIG_ZMK_RGB_UNDERGLOW=y


### PR DESCRIPTION
## Summary
- disable NiceView/OLED related configs in `sofle.conf`
- document how to keep the display disabled in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885df9056b083318d1544406a789ef4